### PR TITLE
Make signing and verification use stricter checks

### DIFF
--- a/Sparkle/SUCodeSigningVerifier.m
+++ b/Sparkle/SUCodeSigningVerifier.m
@@ -48,7 +48,7 @@
     // See https://github.com/sparkle-project/Sparkle/issues/376#issuecomment-48824267 and https://developer.apple.com/library/mac/technotes/tn2206
     // Aditionally, there are several reasons to stay away from deep verification and to prefer DSA signing the download archive instead.
     // See https://github.com/sparkle-project/Sparkle/pull/523#commitcomment-17549302 and https://github.com/sparkle-project/Sparkle/issues/543
-    SecCSFlags flags = (SecCSFlags) (kSecCSDefaultFlags | kSecCSCheckAllArchitectures);
+    SecCSFlags flags = (SecCSFlags) (kSecCSDefaultFlags | | kSecCSCheckNestedCode | kSecCSCheckAllArchitectures | kSecCSEnforceRevocationChecks | kSecCSCheckNestedCode | kSecCSStrictValidate );
     result = SecStaticCodeCheckValidityWithErrors(staticCode, flags, requirement, &cfError);
     
     if (cfError) {


### PR DESCRIPTION
This commit adds some new flags to the codesigning and checking portion of Sparkle for the purposes of stronger security.

Closes https://github.com/brave/Sparkle/issues/5