### PR TITLE
Build BinaryDelta for Sparkle

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -19,6 +19,9 @@ bundle_data("sparkle_resources_bundle_data") {
 action("build_sparkle_framework") {
   script="build_sparkle_framework.py"
 
-  outputs = [ "$root_out_dir/Sparkle.framework" ]
+  outputs = [
+    "$root_out_dir/Sparkle.framework",
+    "$root_out_dir/BinaryDelta"
+  ]
 }
 

--- a/build_sparkle_framework.py
+++ b/build_sparkle_framework.py
@@ -31,6 +31,12 @@ def Main(args):
       print(e.output)
       raise e
 
+  command = ['xcodebuild', '-target', 'BinaryDelta', '-configuration', 'Release']
+  try:
+      subprocess.check_call(command, stdout=FNULL)
+  except subprocess.CalledProcessError as e:
+      print(e.output)
+      raise e
 
   return 0
 

--- a/build_sparkle_framework.py
+++ b/build_sparkle_framework.py
@@ -31,7 +31,7 @@ def Main(args):
       print(e.output)
       raise e
 
-  command = ['xcodebuild', '-target', 'BinaryDelta', '-configuration', 'Release']
+  command = ['xcodebuild', '-target', 'BinaryDelta', '-configuration', 'Release', out_dir_config, 'build']
   try:
       subprocess.check_call(command, stdout=FNULL)
   except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Output will go into vendor/sparkle/build
tree as opposed to src/out tree as it will
not be bundled with Brave, but rather used
to build the Sparkle delta.

Resolves: https://github.com/brave/Sparkle/issues/9