### PR TITLE
Add method checkForUpdatesInBackgroundWithoutUi

### DIFF
--- a/Sparkle/SUUpdater.h
+++ b/Sparkle/SUUpdater.h
@@ -85,6 +85,15 @@ SU_EXPORT @interface SUUpdater : NSObject
  */
 - (void)checkForUpdatesInBackground;
 
+/*!
+ Checks for updates and never displays any UI.
+
+ This is unlike checkForUpdatesInBackground, which may display a UI in some cases.
+ Specifically, checkForUpdatesInBackground displays the "Update available" popup
+ when an update is available but the current user does not have write access to
+ the app installation directory. checkForUpdatesInBackgroundWithoutUi avoids this.
+ */
+
 - (void)checkForUpdatesInBackgroundWithoutUi;
 
 /*!

--- a/Sparkle/SUUpdater.h
+++ b/Sparkle/SUUpdater.h
@@ -85,6 +85,8 @@ SU_EXPORT @interface SUUpdater : NSObject
  */
 - (void)checkForUpdatesInBackground;
 
+- (void)checkForUpdatesInBackgroundWithoutUi;
+
 /*!
  A property indicating whether or not to check for updates automatically.
 

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -340,6 +340,11 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     [self checkForUpdatesWithDriver:theUpdateDriver];
 }
 
+- (void)checkForUpdatesInBackgroundWithoutUi
+{
+    [self checkForUpdatesWithDriver:[[SUAutomaticUpdateDriver alloc] initWithUpdater:self]];
+}
+
 - (IBAction)checkForUpdates:(id)__unused sender
 {
     if (self.driver && [self.driver isInterruptible]) {


### PR DESCRIPTION
This lets us prevent Sparkle's "Update available" popup when a background update check finds an update but cannot write to the
app installation directory.

See https://github.com/brave/brave-core/pull/12335/