### PR TITLE
Add GN target for tarring our Sparkle binaries

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -29,3 +29,11 @@ copy("copy_old_sign_update") {
     "$root_out_dir/old_dsa_scripts/{{source_file_part}}",
   ]
 }
+
+action("tar_sparkle_binaries") {
+  script="tar_sparkle_binaries.py"
+
+  outputs = [ "$root_out_dir/sparkle_binaries.tar.gz" ]
+
+  deps = [ ":build_sparkle_framework" ]
+}

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -4,14 +4,12 @@
 
 assert(is_mac)
 
-config("sparkle_binaries") {
-  sparkle_binaries = [
-    "Sparkle.framework",
-    "BinaryDelta",
-    "generate_keys",
-    "sign_update"
-  ]
-}
+sparkle_binaries = [
+  "Sparkle.framework",
+  "BinaryDelta",
+  "generate_keys",
+  "sign_update"
+]
 
 bundle_data("sparkle_framework_bundle_data") {
   public_deps = [ ":build_sparkle_framework" ]
@@ -22,7 +20,6 @@ bundle_data("sparkle_framework_bundle_data") {
 
 action("build_sparkle_framework") {
   script="build_sparkle_framework.py"
-  configs += [ ":sparkle_binaries" ]
   outputs = []
   foreach(binary, sparkle_binaries) {
     outputs += [ "$root_out_dir/" + binary ]
@@ -41,8 +38,6 @@ action("tar_sparkle_binaries") {
   script="tar_sparkle_binaries.py"
 
   outputs = [ "$root_out_dir/sparkle_binaries.tar.gz" ]
-
-  configs += [ ":sparkle_binaries" ]
 
   args = sparkle_binaries
 

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -4,6 +4,15 @@
 
 assert(is_mac)
 
+config("sparkle_binaries") {
+  sparkle_binaries = [
+    "Sparkle.framework",
+    "BinaryDelta",
+    "generate_keys",
+    "sign_update"
+  ]
+}
+
 bundle_data("sparkle_framework_bundle_data") {
   public_deps = [ ":build_sparkle_framework" ]
 
@@ -13,13 +22,11 @@ bundle_data("sparkle_framework_bundle_data") {
 
 action("build_sparkle_framework") {
   script="build_sparkle_framework.py"
-
-  outputs = [
-    "$root_out_dir/Sparkle.framework",
-    "$root_out_dir/BinaryDelta",
-    "$root_out_dir/generate_keys",
-    "$root_out_dir/sign_update",
-  ]
+  configs += [ ":sparkle_binaries" ]
+  outputs = []
+  foreach(binary, sparkle_binaries) {
+    outputs += [ "$root_out_dir/" + binary ]
+  }
 }
 
 copy("copy_old_sign_update") {
@@ -34,6 +41,10 @@ action("tar_sparkle_binaries") {
   script="tar_sparkle_binaries.py"
 
   outputs = [ "$root_out_dir/sparkle_binaries.tar.gz" ]
+
+  configs += [ ":sparkle_binaries" ]
+
+  args = sparkle_binaries
 
   deps = [ ":build_sparkle_framework" ]
 }

--- a/tar_sparkle_binaries.py
+++ b/tar_sparkle_binaries.py
@@ -1,0 +1,18 @@
+import os
+import os.path
+import tarfile
+
+
+def main():
+    with tarfile.open('sparkle_binaries.tar.gz', 'w:gz') as tar:
+        for f in ('Sparkle.framework', 'BinaryDelta', 'generate_keys',
+                  'sign_update'):
+            tar.add(f)
+        sparkle_src_dir = os.path.dirname(os.path.realpath(__file__))
+        sign_update_dsa = os.path.join(sparkle_src_dir, 'bin',
+                                       'old_dsa_scripts', 'sign_update')
+        tar.add(sign_update_dsa, arcname='sign_update_dsa')
+
+
+if __name__ == '__main__':
+    main()

--- a/tar_sparkle_binaries.py
+++ b/tar_sparkle_binaries.py
@@ -1,12 +1,12 @@
 import os
 import os.path
+import sys
 import tarfile
 
 
 def main():
     with tarfile.open('sparkle_binaries.tar.gz', 'w:gz') as tar:
-        for f in ('Sparkle.framework', 'BinaryDelta', 'generate_keys',
-                  'sign_update'):
+        for f in sys.argv[1:]:
             tar.add(f)
         sparkle_src_dir = os.path.dirname(os.path.realpath(__file__))
         sign_update_dsa = os.path.join(sparkle_src_dir, 'bin',


### PR DESCRIPTION
The produced .tar.gz then gets included in Brave, which is particularly useful for cross-compiling from Linux to macOS.

This supersedes #20. The reason for the change is that we want to keep the targets for building Sparkle in brave-core.